### PR TITLE
Refactor Configuration

### DIFF
--- a/httpserver-conf.lua
+++ b/httpserver-conf.lua
@@ -4,12 +4,35 @@
 
 local conf = {}
 
--- Basic Authentication Conf
-local auth = {}
-auth.enabled = true
-auth.realm = "nodemcu-httpserver" -- displayed in the login dialog users get
-auth.user = "user"
-auth.password = "password" -- PLEASE change this
-conf.auth = auth
+-- Basic HTTP Authentication Conf
+conf.auth = {}
+conf.auth.enabled = true
+conf.auth.realm = "nodemcu-httpserver" -- displayed in the login dialog users get
+conf.auth.user = "user"
+conf.auth.password = "password" -- PLEASE change this
+
+-- Configuration for WiFi AP / Client Modes
+conf.wifi = {}
+-- wifi.STATION         -- station: join a WiFi network
+-- wifi.SOFTAP          -- access point: create a WiFi network
+-- wifi.wifi.STATIONAP  -- both station and access point
+conf.wifi.mode = wifi.STATIONAP  -- both station and access point
+
+-- Access Point
+conf.wifi.AP = {}
+conf.wifi.AP.config = {}
+conf.wifi.AP.config.ssid = "ESP-"..node.chipid()   -- Name of the SSID you want to create
+conf.wifi.AP.config.pwd = conf.auth.password       -- marginally more secure than the SSID?
+
+-- Access Point IP
+conf.wifi.AP.ip = {}
+conf.wifi.AP.ip.ip = "192.168.1.1"
+conf.wifi.AP.ip.netmask = "255.255.255.0"
+conf.wifi.AP.ip.gateway = "192.168.1.1"
+
+-- Client config
+conf.wifi.client = {}
+conf.wifi.client.ssid = "YOUR_INTERNET" -- Name of the WiFi network you want to join
+conf.wifi.client.pwd =  "YOUR_PASSWORD"	-- Password for the WiFi network
 
 return conf

--- a/init.lua
+++ b/init.lua
@@ -1,44 +1,24 @@
 -- Begin WiFi configuration
-
-local wifiConfig = {}
-
--- wifi.STATION         -- station: join a WiFi network
--- wifi.SOFTAP          -- access point: create a WiFi network
--- wifi.wifi.STATIONAP  -- both station and access point
-wifiConfig.mode = wifi.STATIONAP  -- both station and access point
-
-wifiConfig.accessPointConfig = {}
-wifiConfig.accessPointConfig.ssid = "ESP-"..node.chipid()   -- Name of the SSID you want to create
-wifiConfig.accessPointConfig.pwd = "ESP-"..node.chipid()    -- WiFi password - at least 8 characters
-
-wifiConfig.accessPointIpConfig = {}
-wifiConfig.accessPointIpConfig.ip = "192.168.111.1"
-wifiConfig.accessPointIpConfig.netmask = "255.255.255.0"
-wifiConfig.accessPointIpConfig.gateway = "192.168.111.1"
-
-wifiConfig.stationPointConfig = {}
-wifiConfig.stationPointConfig.ssid = "Internet"        -- Name of the WiFi network you want to join
-wifiConfig.stationPointConfig.pwd =  ""                -- Password for the WiFi network
+conf = dofile("httpserver-conf.lc")
 
 -- Tell the chip to connect to the access point
 
-wifi.setmode(wifiConfig.mode)
-print('set (mode='..wifi.getmode()..')')
+wifi.setmode(conf.wifi.mode)
+print('Wifi Mode:'..wifi.getmode())
 
-if (wifiConfig.mode == wifi.SOFTAP) or (wifiConfig.mode == wifi.STATIONAP) then
-    print('AP MAC: ',wifi.ap.getmac())
-    wifi.ap.config(wifiConfig.accessPointConfig)
-    wifi.ap.setip(wifiConfig.accessPointIpConfig)
+if (conf.wifi.mode == wifi.SOFTAP) or (conf.wifi.mode == wifi.STATIONAP) then
+    print('AP MAC: '..wifi.ap.getmac())
+    wifi.ap.config(conf.wifi.AP.config)
+    wifi.ap.setip(conf.wifi.AP.ip)
 end
-if (wifiConfig.mode == wifi.STATION) or (wifiConfig.mode == wifi.STATIONAP) then
-    print('Client MAC: ',wifi.sta.getmac())
-    wifi.sta.config(wifiConfig.stationPointConfig.ssid, wifiConfig.stationPointConfig.pwd, 1)
+if (conf.wifi.mode == wifi.STATION) or (conf.wifi.mode == wifi.STATIONAP) then
+    print('Client MAC: '..wifi.sta.getmac())
+    wifi.sta.config(conf.wifi.client.ssid, conf.wifi.client.pwd, 1)
 end
 
-print('chip: ',node.chipid())
-print('heap: ',node.heap())
+print('Chip: '..node.chipid()..' Heap: '..node.heap())
 
-wifiConfig = nil
+conf = nil
 collectgarbage()
 
 -- End WiFi configuration


### PR DESCRIPTION
Moved all configuration settings into httpserver-config.lua and made
init load the conf.
Updated AP IP to 192.168.1.1, as that is a wide standard and makes
direct connections very easy.
Updated AP default password to use the auth password by default, as this
seems more secure than it matching the SSID and is slightly more
convenient.
